### PR TITLE
fix(android): bar and rim with same width and hide text

### DIFF
--- a/src/animated-circle.android.ts
+++ b/src/animated-circle.android.ts
@@ -33,6 +33,7 @@ export class AnimatedCircle extends Common {
     }
 
     initNativeView() {
+        this.android.setTextSize(0);
         this.updateAnimatedCircle();
     }
 
@@ -160,6 +161,7 @@ export class AnimatedCircle extends Common {
             }
             if (this.rimWidth) {
                 this.android.setRimWidth(this.rimWidth);
+                this.android.setBarWidth(this.rimWidth);
             }
             if (this.barColor) {
                 this.android.setBarColor([new Color(this.barColor).argb]);

--- a/src/animated-circle.android.ts
+++ b/src/animated-circle.android.ts
@@ -1,6 +1,5 @@
 import { Common } from './animated-circle.common';
 import { Color } from 'tns-core-modules/color';
-import * as app from 'tns-core-modules/application/Application';
 
 declare const com, android, at;
 

--- a/src/animated-circle.ios.ts
+++ b/src/animated-circle.ios.ts
@@ -1,5 +1,5 @@
 import { Common } from './animated-circle.common';
-import { Color } from 'tns-core-modules/color/Color';
+import { Color } from 'tns-core-modules/color';
 
 declare const DRCircularProgressView;
 


### PR DESCRIPTION
Hi Sean, 

This fixies 2 issues with the plugin on android.

The first one is to fixies the bar with(now its the same as rim).
The second is to hide the text in the center of the plugin.

Also added some `import` fixies because of ci